### PR TITLE
Android packages latest version copy update

### DIFF
--- a/_source/android/01_getting_started.md
+++ b/_source/android/01_getting_started.md
@@ -23,7 +23,7 @@ Then select API 28 or higher for the minimum SDK and Kotlin DSL for the build co
 
 ## Integrate Hotwire Native
 
-Add the Hotwire Native dependencies to your app's module (not top-level) `build.gradle.kts` file. You can look up the version number from `https://github.com/orgs/hotwired/packages`.
+Add the Hotwire Native dependencies to your app's module (not top-level) `build.gradle.kts` file. You can look up the version number from [https://github.com/orgs/hotwired/packages](https://github.com/orgs/hotwired/packages).
 
 ```kotlin
 dependencies {

--- a/_source/android/01_getting_started.md
+++ b/_source/android/01_getting_started.md
@@ -23,7 +23,7 @@ Then select API 28 or higher for the minimum SDK and Kotlin DSL for the build co
 
 ## Integrate Hotwire Native
 
-Add the Hotwire Native dependencies to your app's module (not top-level) `build.gradle.kts` file:
+Add the Hotwire Native dependencies to your app's module (not top-level) `build.gradle.kts` file. You can look up the version number from `https://github.com/orgs/hotwired/packages`.
 
 ```kotlin
 dependencies {


### PR DESCRIPTION
## Changes
Small copy change to include where to find the version number to replace `<latest-version>` with for the Android packages.

<img width="975" alt="Screenshot 2024-09-27 at 20 36 23" src="https://github.com/user-attachments/assets/afe3cba5-e180-4d5c-8655-1cba319bf864">

