### PR TITLE
Update Getting Started instructions for Android

### DIFF
--- a/_source/android/01_getting_started.md
+++ b/_source/android/01_getting_started.md
@@ -55,6 +55,9 @@ Set up the app's layout by opening `activity_main.xml` and replace the entire fi
 Finally, open `MainActivity.kt` and replace the class with this code:
 
 ```kotlin
+// use the namespace of your application as listed in the app-level `build.gradle.kts` under `android / namespace`:
+package com.example.myapplication
+
 import android.os.Bundle
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration


### PR DESCRIPTION
**This PR:**
- Closes [Issue 51: Getting Started instructions for Android cause build failure](https://github.com/hotwired/hotwire-native-site/issues/51)

Without a `package` reference in `MainActivity.kt`, building the project leads to two errors that look like this:

```
e: file:///path/to/application/MyApplication/app/src/main/java/com/example/myapplication/MainActivity.kt:8:24
Unresolved reference: R
```