### PR TITLE
Fix server navigation URLs

### DIFF
--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -156,15 +156,15 @@ Add the following to your path configuration to apply the presentation logic.
   "settings": {},
   "rules": [
     {
-      "patterns": ["/turbo_recede_historical_location_url"],
+      "patterns": [turbo_recede_historical_location_url],
       "properties": {"presentation": "pop"}
     },
     {
-      "patterns": ["/turbo_resume_historical_location_url"],
+      "patterns": [turbo_resume_historical_location_url],
       "properties": {"presentation": "none"}
     },
     {
-      "patterns": ["/turbo_refresh_historical_location_url"],
+      "patterns": [turbo_refresh_historical_location_url],
       "properties": {"presentation": "refresh"}
     }
   ]


### PR DESCRIPTION
This fixes an issue in the docs where a Rails method was wrapped in double quotes, making it look like the URL instead of a method call.

Fixes #55.