### PR TITLE
Explain where to put the PathConfiguration code if following Getting Started guide

### DIFF
--- a/_source/ios/02_path_configuration.md
+++ b/_source/ios/02_path_configuration.md
@@ -61,6 +61,8 @@ If you provide both a file and a server location, the path configuration will be
 2. A locally cached copy of the server configuration (if a successful download occurred on a previous app launch).
 3. A newly downloaded copy of the server configuration. (Once this has downloaded successfully, it will be cached and used in step 2 on the next app launch.) 
 
+The PathConfiguration must be passed into your Navigator, so if you followed the [getting started](/ios/getting-started) steps, this code should go into the `SceneDelegate` class.
+
 ## Query String Matching
 
 By default, path patterns match against the path component *and* query string of the URL.


### PR DESCRIPTION
When I first went through this I didn't know where to put the code so I figured this would be helpful. Technically the code will need some changes (e.g. make the navigator lazy initialized) if pasted into that sample SceneDelegate, but Xcode helps point out those changes.

Fixes #54