### PR TITLE
Update SceneDelegate code in "Getting Started" for iOS

### DIFF
--- a/_source/ios/01_getting_started.md
+++ b/_source/ios/01_getting_started.md
@@ -50,6 +50,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private let navigator = Navigator()
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        window = UIWindow(windowScene: windowScene)
+        window?.makeKeyAndVisible()
+
         window?.rootViewController = navigator.rootViewController
         navigator.route(rootURL)
     }


### PR DESCRIPTION
With the existing code (XCode 15) the Simulator opens the app but the app only shows a black screen:

![before](https://github.com/user-attachments/assets/a87ca485-5f1b-43e4-af33-ab4e848c7ed2)

After this commit, the app shows the website as intended:

![after](https://github.com/user-attachments/assets/94c4193c-f448-48d2-ae8e-e146f904210f)

I copied the missing lines from the "Demo" folder inside hotwire-native-ios:

https://github.com/hotwired/hotwire-native-ios/blob/f52aa92c4f9bb95ef6d5fa9b58d9553d05fbb3c5/Demo/SceneController.swift#L46-L49