### PR TITLE
Fix small error in iOS documentation

### DIFF
--- a/_source/ios/03_bridge_components.md
+++ b/_source/ios/03_bridge_components.md
@@ -98,7 +98,7 @@ First, the component identifies itself as `"button"` via `name` to match the Sti
 
 `onReceive(message:)` is called when a message is received from Stimulus. Here, the `{title}` object is unpacked to add a native button to the right side of the screen. When it's tapped, the `UIAction` is fired, replying to the message and calling the callback block, clicking the button.
 
-Finally, register the component. If you followed the [getting started steps](/ios/getting-started) then this will go in `SceneDelegate.swift` before routing your first URL.
+Finally, register the component. If you followed the [getting started steps](/ios/getting-started) then this will go in `SceneDelegate.swift` before accessing the rootViewController of the navigatorL.
 
 ```swift
 Hotwire.registerBridgeComponents([


### PR DESCRIPTION
This fixes a small error in the iOS documentation that I ran into. The old documentation stated that the bridge components must be registered before routing your first URL. However, because the userAgent is checked to determine if we are in a Hotwire app and therefore if the bridge components should be activated **and** because this userAgent is established when the root view controller is created you need to register your bridge components first.