### PR TITLE
Update Android Getting started instructions to support SDK 35

### DIFF
--- a/_source/android/01_getting_started.md
+++ b/_source/android/01_getting_started.md
@@ -58,6 +58,7 @@ Finally, open `MainActivity.kt` and replace the class with this code:
 package com.example.myapplication // update to match your project
 
 import android.os.Bundle
+import android.view.View
 import androidx.activity.enableEdgeToEdge
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat

--- a/_source/android/01_getting_started.md
+++ b/_source/android/01_getting_started.md
@@ -59,7 +59,6 @@ package com.example.myapplication // update to match your project
 
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import dev.hotwire.navigation.activities.HotwireActivity

--- a/_source/android/01_getting_started.md
+++ b/_source/android/01_getting_started.md
@@ -55,14 +55,29 @@ Set up the app's layout by opening `activity_main.xml` and replace the entire fi
 Finally, open `MainActivity.kt` and replace the class with this code:
 
 ```kotlin
+package com.example.myapplication // update to match your project
+
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
 
 class MainActivity : HotwireActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // handle window insets:
+        val rootView = findViewById<View>(R.id.main_nav_host)
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
+            val insetTypes = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.ime()
+            insets.getInsets(insetTypes).apply { v.setPadding(left, top, right, bottom) }
+            insets
+        }
     }
 
     override fun navigatorConfigurations() = listOf(

--- a/_source/android/01_getting_started.md
+++ b/_source/android/01_getting_started.md
@@ -69,7 +69,7 @@ class MainActivity : HotwireActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        findViewById<View>(R.id.main_nav_host).applyDefaultWindowInsets()
+        findViewById<View>(R.id.main_nav_host).applyDefaultImeWindowInsets()
     }
 
     override fun navigatorConfigurations() = listOf(

--- a/_source/android/01_getting_started.md
+++ b/_source/android/01_getting_started.md
@@ -60,24 +60,16 @@ package com.example.myapplication // update to match your project
 import android.os.Bundle
 import android.view.View
 import androidx.activity.enableEdgeToEdge
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
+import dev.hotwire.navigation.util.applyDefaultWindowInsets
 
 class MainActivity : HotwireActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
-        // handle window insets:
-        val rootView = findViewById<View>(R.id.main_nav_host)
-        ViewCompat.setOnApplyWindowInsetsListener(rootView) { v, insets ->
-            val insetTypes = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.ime()
-            insets.getInsets(insetTypes).apply { v.setPadding(left, top, right, bottom) }
-            insets
-        }
+        findViewById<View>(R.id.main_nav_host).applyDefaultWindowInsets()
     }
 
     override fun navigatorConfigurations() = listOf(


### PR DESCRIPTION
Android SDK 35 comes with Edge-to-edge feature on by default. This means that Android Getting started instructions should now include insets handling to avoid the resulting app being incorrectly rendered (especially the navigation bar being inaccessible due to being drawn behind the status bar).

This PR adds the necessary code for `MainActivity` to support correct insets handling.

It also addresses https://github.com/hotwired/hotwire-native-site/issues/51 (build issues due to missing package definition)