### PR TITLE
Presentation column presenting camelCase

### DIFF
--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -115,7 +115,7 @@ Set `context` or `presentation` to a [path configuration](/reference/path-config
     <tr>
       <td>(any)</td>
       <td>(any)</td>
-      <td><code>clearAll</code></td>
+      <td><code>clear_all</code></td>
       <td>
         Dismiss if modal screen then<br>
         Pop to root then<br>
@@ -125,7 +125,7 @@ Set `context` or `presentation` to a [path configuration](/reference/path-config
     <tr>
       <td>(any)</td>
       <td>(any)</td>
-      <td><code>replaceRoot</code></td>
+      <td><code>replace_root</code></td>
       <td>
         Dismiss if modal screen then<br>
         Pop to root then<br>


### PR DESCRIPTION
The column Presentation was presenting clear_all as clearAll and replace_root as replaceRoot. 

I noticed this when doing iOS development as I was not seeing the expected behaviour. 


## Before

![CleanShot 2025-02-13 at 14 35 44](https://github.com/user-attachments/assets/d8136f9d-781d-46d1-ba81-fd69a328535b)


## After
![CleanShot 2025-02-13 at 14 34 41](https://github.com/user-attachments/assets/70fd1617-5443-4aa3-9373-f8740ea8c8ca)


