### PR TITLE
Update android applyDefaultImeWindowInsets import

### DIFF
--- a/_source/android/01_getting_started.md
+++ b/_source/android/01_getting_started.md
@@ -62,7 +62,7 @@ import android.view.View
 import androidx.activity.enableEdgeToEdge
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
-import dev.hotwire.navigation.util.applyDefaultWindowInsets
+import dev.hotwire.navigation.util.applyDefaultImeWindowInsets
 
 class MainActivity : HotwireActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
Looks like this was changed recently in the `onCreate` function but not the import.