### PR TITLE
API documentation changes for `v1.2.0`

### DIFF
--- a/_source/android/06_reference.md
+++ b/_source/android/06_reference.md
@@ -21,24 +21,6 @@ Hotwire.config.makeCustomWebView = { context ->
 }
 ```
 
-## Handling URL routes
-
-By default, all external urls outside of your app's domain are opened in the default browser on the device. This is easily customizable, though. Out-of-the-box, Hotwire Native provides three route decision handlers for you to use to control how urls are routed:
-- `AppNavigationRouteDecisionHandler`: Routes all internal urls through your app (enabled by default).
-- `BrowserRouteDecisionHandler`: Routes all external urls to the device's default browser (enabled by default).
-- `BrowserTabRouteDecisionHandler`: Routes all external urls to a [Custom Tab](https://developer.chrome.com/docs/android/custom-tabs) in your app (disabled by default).
-
-If you'd like to customize this behavior, it's easy to do. For example, if you'd like to route external urls to Custom Tabs instead of the default browser, you can register the relevant decision handlers in order of importance:
-
-```kotlin
-Hotwire.registerRouteDecisionHandlers(
-    AppNavigationRouteDecisionHandler(),
-    BrowserTabRouteDecisionHandler()
-)
-```
-
-You can also implement your own `Router.RouteDecisionHandler` classes and register them the same way.
-
 ## Custom HTML data attributes
 
 - `data-native-prevent-pull-to-refresh`: Apply to any element in your web app whose touch events conflict with the native pull-to-refresh behavior in the `WebView`. By default, scrollable elements prevent pull-to-refresh, but you may need to apply this custom attribute to elements that have draggable or swipeable behaviors.

--- a/_source/overview/02_basic_navigation.md
+++ b/_source/overview/02_basic_navigation.md
@@ -34,6 +34,8 @@ The framework also applies a few sane defaults. Navigating to the _current_ page
 
 Note that if the URL of a tapped link is _not_ on the same domain as the current page it is considered _external_. External links are not routed through Hotwire Native. They instead open via an in-app web browser. iOS uses an [`SFSafariViewController`](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller) and Android uses [Custom Tabs](https://developer.chrome.com/docs/android/custom-tabs).
 
+See the <a href="/reference/navigation#route-decision-handlers">Route Decision Handler</a> documentation to learn how urls are routed and how to customize the default behavior.
+
 ## Advanced Navigation
 
 Hotwire Native supports a bunch of other navigation patterns like popping the entire stack and manually refreshing the current page. But individually decorating each link would create a maintenance nightmare.

--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -143,33 +143,13 @@ Set `context` or `presentation` to a [path configuration](/reference/path-config
 
 ### Server-Driven Routing in Rails
 
-If you're using Ruby on Rails, the [turbo-rails](https://github.com/hotwired/turbo-rails) gem provides the following additional routes. Use these to customize the behavior for Hotwire Native apps but falling back to redirecting elsewhere.
+If you're using Ruby on Rails, the [turbo-rails](https://github.com/hotwired/turbo-rails) gem provides the following additional historical location routes. Use these to manipulate the navigation stack for Hotwire Native apps, and falling back to redirecting elsewhere.
 
-* `recede_or_redirect_to(url, **options)` - Pops the visible screen off of the navigation stack. If a modal is presented on iOS, the modal is dismissed instead.
-* `resume_or_redirect_to(url **options)` - No action is taken.
-* `refresh_or_redirect_to(url, **options)` - Reloads the visible screen by performing a new web request and invalidating the cache.
+* `recede_or_redirect_to(url, **options)` - First, pops any modal screen (if present) off the navigation stack. Then, pops the visible screen off of the navigation stack.
+* `refresh_or_redirect_to(url, **options)` - First, pops any modal screen (if present) off the navigation stack. Then, reloads the visible screen by performing a new web request and invalidating the cache.
+* `resume_or_redirect_to(url **options)` - Pops any modal screen (if present) off the navigation stack. No further action is taken.
 
-Add the following to your path configuration to apply the presentation logic.
-
-```json
-{
-  "settings": {},
-  "rules": [
-    {
-      "patterns": ["/turbo_recede_historical_location_url"],
-      "properties": {"presentation": "pop"}
-    },
-    {
-      "patterns": ["/turbo_resume_historical_location_url"],
-      "properties": {"presentation": "none"}
-    },
-    {
-      "patterns": ["/turbo_refresh_historical_location_url"],
-      "properties": {"presentation": "refresh"}
-    }
-  ]
-}
-```
+The iOS and Android frameworks (starting in version `1.2.0`) automatically support these these historical location urls.
 
 ## Manual Navigation
 

--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -151,6 +151,23 @@ If you're using Ruby on Rails, the [turbo-rails](https://github.com/hotwired/tur
 
 The iOS and Android frameworks (starting in version `1.2.0`) automatically support these these historical location urls.
 
+## Route Decision Handlers
+
+By default, all external urls outside of your app's domain open externally. The specific behavior can be customized, though. Out-of-the-box, Hotwire Native registers these route decision handlers to control how urls are routed:
+- `AppNavigationRouteDecisionHandler`: Routes all internal urls on your app's domain through your app.
+- `SafariViewControllerRouteDecisionHandler`: **(iOS Only)** Routes all external `http`/`https` urls to a [SFSafariViewController](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller) in your app.
+- `BrowserTabRouteDecisionHandler`: **(Android Only)** Routes all external `http`/`https` urls to a [Custom Tab](https://developer.chrome.com/docs/android/custom-tabs) in your app.
+- `SystemNavigationRouteDecisionHandler`: Routes all remaining external urls (such as `sms:` or `mailto:`) through device's system navigation.
+
+If you'd like to customize this behavior, it's easy to do. You can subclass the `RouteDecisionHandler` class in your app to provide your own implementation(s). Register your app's decision handlers in order of importance:
+
+```kotlin
+Hotwire.registerRouteDecisionHandlers(
+    AppNavigationRouteDecisionHandler(),
+    MyCustomExternalRouteDecisionHandler()
+)
+```
+
 ## Manual Navigation
 
 `Navigator` can be used to navigate from a [native screen](/overview/native-screens) to another native screen or back to a web context.

--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -159,7 +159,7 @@ By default, all external urls outside of your app's domain open externally. The 
 - `BrowserTabRouteDecisionHandler`: **(Android Only)** Routes all external `http`/`https` urls to a [Custom Tab](https://developer.chrome.com/docs/android/custom-tabs) in your app.
 - `SystemNavigationRouteDecisionHandler`: Routes all remaining external urls (such as `sms:` or `mailto:`) through device's system navigation.
 
-If you'd like to customize this behavior, it's easy to do. You can subclass the `RouteDecisionHandler` class in your app to provide your own implementation(s). Register your app's decision handlers in order of importance:
+If you'd like to customize this behavior you can subclass the `RouteDecisionHandler` class in your app to provide your own implementation(s). Register your app's decision handlers in order of importance:
 
 ```kotlin
 Hotwire.registerRouteDecisionHandlers(

--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -161,6 +161,15 @@ By default, all external urls outside of your app's domain open externally. The 
 
 If you'd like to customize this behavior you can subclass the `RouteDecisionHandler` class in your app to provide your own implementation(s). Register your app's decision handlers in order of importance. To decide how a url should be routed, the registered `RouteDecisionHandler` instances are called in order. When a matching `RouteDecisionHandler` is found for a given url, its `handle()` function is called and no other `RouteDecisionHandler` instances will be subsequently called.
 
+**Example for iOS:**
+```swift
+Hotwire.registerRouteDecisionHandlers([
+    AppNavigationRouteDecisionHandler(),
+    MyCustomExternalRouteDecisionHandler()
+])
+```
+
+**Example for Android:**
 ```kotlin
 Hotwire.registerRouteDecisionHandlers(
     AppNavigationRouteDecisionHandler(),

--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -159,7 +159,7 @@ By default, all external urls outside of your app's domain open externally. The 
 - `BrowserTabRouteDecisionHandler`: **(Android Only)** Routes all external `http`/`https` urls to a [Custom Tab](https://developer.chrome.com/docs/android/custom-tabs) in your app.
 - `SystemNavigationRouteDecisionHandler`: Routes all remaining external urls (such as `sms:` or `mailto:`) through device's system navigation.
 
-If you'd like to customize this behavior you can subclass the `RouteDecisionHandler` class in your app to provide your own implementation(s). Register your app's decision handlers in order of importance:
+If you'd like to customize this behavior you can subclass the `RouteDecisionHandler` class in your app to provide your own implementation(s). Register your app's decision handlers in order of importance. To decide how a url should be routed, the registered `RouteDecisionHandler` instances are called in order. When a matching `RouteDecisionHandler` is found for a given url, its `handle()` function is called and no other `RouteDecisionHandler` instances will be subsequently called.
 
 ```kotlin
 Hotwire.registerRouteDecisionHandlers(

--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -143,7 +143,7 @@ Set `context` or `presentation` to a [path configuration](/reference/path-config
 
 ### Server-Driven Routing in Rails
 
-If you're using Ruby on Rails, the [turbo-rails](https://github.com/hotwired/turbo-rails) gem provides the following additional historical location routes. Use these to manipulate the navigation stack for Hotwire Native apps, and falling back to redirecting elsewhere.
+If you're using Ruby on Rails, the [turbo-rails](https://github.com/hotwired/turbo-rails) gem provides the following additional historical location routes. Use these to manipulate the navigation stack for Hotwire Native apps, falling back to redirecting elsewhere.
 
 * `recede_or_redirect_to(url, **options)` - First, pops any modal screen (if present) off the navigation stack. Then, pops the visible screen off of the navigation stack.
 * `refresh_or_redirect_to(url, **options)` - First, pops any modal screen (if present) off the navigation stack. Then, reloads the visible screen by performing a new web request and invalidating the cache.


### PR DESCRIPTION
This updates the documentation for:

- Route Decision Handlers
- Server-driven historical location urls