### PR TITLE
Clarify defaultViewController and defaultNavigationController

### DIFF
--- a/_source/ios/05_configuration.md
+++ b/_source/ios/05_configuration.md
@@ -21,8 +21,8 @@ Hotwire Native provides a few options to customize your iOS app. We recommend ma
 
 ## Turbo
 
-* `Hotwire.config.defaultViewController` - The view controller used in `Navigator` for web requests. Must be a `VisitableViewController` or subclass.
-* `Hotwire.config.defaultNavigationController` - The navigation controller used in `Navigator` for the main and modal stacks. Must be a `UINavigationController` or subclass.
+* `Hotwire.config.defaultViewController` - The view controller used in `Navigator` for web requests. Must be a `VisitableViewController` or subclass. By default, this is an instance of `HotwireWebViewController`.
+* `Hotwire.config.defaultNavigationController` - The navigation controller used in `Navigator` for the main and modal stacks. Must be a `UINavigationController` or subclass. By default, this is an instance of `HotwireNavigationController`.
 * `Hotwire.config.makeCustomWebView` - Optionally customize the web views used by each Turbo Session. Ensure you return a new instance each time.
 
 ## Path Configuration

--- a/_source/ios/05_configuration.md
+++ b/_source/ios/05_configuration.md
@@ -21,8 +21,22 @@ Hotwire Native provides a few options to customize your iOS app. We recommend ma
 
 ## Turbo
 
-* `Hotwire.config.defaultViewController` - The view controller used in `Navigator` for web requests. Must be a `VisitableViewController` or subclass. By default, this is an instance of `HotwireWebViewController`.
-* `Hotwire.config.defaultNavigationController` - The navigation controller used in `Navigator` for the main and modal stacks. Must be a `UINavigationController` or subclass. By default, this is an instance of `HotwireNavigationController`.
+* `Hotwire.config.defaultViewController` - The view controller used in `Navigator` for web requests. Must be a [`VisitableViewController`](https://github.com/hotwired/hotwire-native-ios/blob/main/Source/Turbo/Visitable/VisitableViewController.swift) or subclass. Defaults to an instance of [`HotwireWebViewController`](https://github.com/hotwired/hotwire-native-ios/blob/main/Source/Turbo/ViewControllers/HotwireWebViewController.swift).
+
+```swift
+Hotwire.config.defaultViewController = { url in
+    CustomViewController(url: url)
+}
+```
+
+* `Hotwire.config.defaultNavigationController` - The navigation controller used in `Navigator` for the main and modal stacks. Must be a [`UINavigationController`](https://developer.apple.com/documentation/uikit/uinavigationcontroller) or subclass. Defaults to an instance of [`HotwireNavigationController`](https://github.com/hotwired/hotwire-native-ios/blob/main/Source/Turbo/ViewControllers/HotwireNavigationController.swift).
+
+```swift
+Hotwire.config.defaultNavigationController = { in
+    CustomNavigationController()
+}
+```
+
 * `Hotwire.config.makeCustomWebView` - Optionally customize the web views used by each Turbo Session. Ensure you return a new instance each time.
 
 ## Path Configuration


### PR DESCRIPTION
The current documentation states the protocol requirements for the `defaultViewController` and `defaultNavigationController` (`VisitableViewController` and `UINavigationController` respectively), but doesn't mention `HotwireWebViewController` or `HotwireNavigationController`. As such, developers may just subclass `VisitableViewController` for example, only to discover that their Bridge Components don't work.

This PR informs developers of these default classes so that they can create the appropriate subclass.