### PR TITLE
note that  HotwireWebFragment::class also needs to be registered

### DIFF
--- a/_source/android/04_native_screens.md
+++ b/_source/android/04_native_screens.md
@@ -41,8 +41,11 @@ class NumbersFragment : HotwireFragment() {
 
 Finally, register this fragment with Hotwire Native to use it when the URL path matches. See the [configuration](/android/configuration) docs for a recommendation on where to register fragments in your code.
 
+Note that if you decide to register your own fragments, you must also register `HotwireWebFragment` for URL paths that do not match your custom fragment's path.
+
 ```kotlin
 Hotwire.registerFragmentDestinations(
+    HotwireWebFragment::class, // Don't forget to register this for regular destinations
     NumbersFragment::class
 )
 ```

--- a/_source/android/05_configuration.md
+++ b/_source/android/05_configuration.md
@@ -50,6 +50,7 @@ Register fragment destinations:
 
 ```kotlin
 Hotwire.registerFragmentDestinations(
+    HotwireWebFragment::class, // Don't forget to register this for regular destinations
     MyCustomFragment::class
 )
 ```


### PR DESCRIPTION
I started to build my first android application with Hotwire Native and tried to add a native screen based on the documentation. 

My app crashed on launch when I tried to register my Native Screen like this: 

```kotlin
Hotwire.registerFragmentDestinations(
    NumbersFragment::class
)
```

After a day of debugging and looking at the provided (really amazing) demo application, I could figure out, that the issue is that I also need to register `HotwireWebFragment` alongside my native screen, like this:

```kotlin
Hotwire.registerFragmentDestinations(
    HotwireWebFragment::class, 
    NumbersFragment::class 
```

The comment in the source code of the [android package explains the reason](https://github.com/hotwired/hotwire-native-android/blob/43830730e3e21769422a0d48228c6dc40c5deda6/navigation-fragments/src/main/java/dev/hotwire/navigation/config/HotwireNavigation.kt#L64): 

```kotlin
/**
 * Register fragment destinations that can be navigated to. Every possible
 * destination must be provided here, including one set via [defaultFragmentDestination].
 */
```

I think it could help beginner android devs (like me), if there is a note about this in the docs, so I added some.

Thank you guys for this great framework, cheers! :pray:  :beers: 
