### PR TITLE
Document custom error views on iOS

### DIFF
--- a/_source/ios/06_reference.md
+++ b/_source/ios/06_reference.md
@@ -46,6 +46,29 @@ Hotwire.config.makeCustomWebView = { config in
 }
 ```
 
+Customize the native error view with a block, making sure to wrap your custom `View` in `AnyView`:
+
+```swift
+Hotwire.config.makeCustomErrorView = { error, handler in
+    AnyView(ExampleErrorView(error: error, handler: handler))
+}
+
+import SwiftUI
+
+struct ExampleErrorView: View {
+    let error: Error
+    let handler: ErrorPresenter.Handler?
+
+    var body: some View {
+        Text(error.localizedDescription)
+
+        if let handler {
+            Button("Retry", action: handler)
+        }
+    }
+}
+```
+
 ## `NavigatorDelegate`
 
 The delegate is an optional interface you can implement to customize behavior of the `Navigator`.


### PR DESCRIPTION
Documents customizing error views introduced in [iOS PR #158](https://github.com/hotwired/hotwire-native-ios/pull/158).