### PR TITLE
Remove trailing slash in jump navigation

### DIFF
--- a/_source/_assets/css/components/_jump.scss
+++ b/_source/_assets/css/components/_jump.scss
@@ -29,7 +29,7 @@
     margin: 0;
     padding: 0;
 
-    &::after {
+    &:not(:last-child)::after {
       content: "/";
       display: inline-block;
       margin: 0 0.25em 0 0.125em;


### PR DESCRIPTION
### Before

<img width="358" height="119" alt="image" src="https://github.com/user-attachments/assets/acc53063-4db7-41ec-85f4-b81745cc44b7" />

### After

<img width="378" height="112" alt="image" src="https://github.com/user-attachments/assets/2609ce51-e9e7-4962-a617-dee3d162df36" />