### PR TITLE
Fix optional chaining for viewController delegate

### DIFF
--- a/_source/ios/03_bridge_components.md
+++ b/_source/ios/03_bridge_components.md
@@ -73,7 +73,7 @@ final class ButtonComponent: BridgeComponent {
     }
 
     private var viewController: UIViewController? {
-        delegate.destination as? UIViewController
+        delegate?.destination as? UIViewController
     }
 
     private func addButton(via message: Message, to viewController: UIViewController) {


### PR DESCRIPTION
Won't compile with Xcode 26:

Value of optional type '(any BridgingDelegate)?' must be unwrapped to refer to member 'destination' of wrapped base type 'any BridgingDelegate'