### PR TITLE
Update Android docs for 1.3.0

### DIFF
--- a/_source/android/02_tabs.md
+++ b/_source/android/02_tabs.md
@@ -1,0 +1,137 @@
+---
+permalink: /android/tabs.html
+order: 02
+title: "Tabs"
+description: "How to add bottom tabs to a Hotwire Native app on Android."
+---
+
+# Tabs
+
+A native bottom tab bar elevates a Hotwire Native app to make it feel more like a native app. Under the hood, Hotwire Native drives a standard `BottomNavigationView` from [Material Components](https://github.com/material-components/material-components-android). This means all the expected features work out of the box, including:
+
+* Customization for tab titles and icons
+* A separate navigator and navigation stack for each tab
+* Reselecting the active tab clears its stack back to the start screen
+
+## Add a bottom navigation view
+
+We'll build on top of the app from the [Getting Started guide](/android/getting-started). Each tab needs its own `NavigatorHost` in the layout so it maintains its own navigation stack. From there, replace the contents of `activity_main.xml` with the following:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/navigation_navigator_host"
+        android:name="dev.hotwire.navigation.navigator.NavigatorHost"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_nav"
+        app:defaultNavHost="false" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/bridge_components_navigator_host"
+        android:name="dev.hotwire.navigation.navigator.NavigatorHost"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_nav"
+        app:defaultNavHost="false" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_nav"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>
+```
+
+## Define the tabs
+
+Then, define a tab for each `NavigatorHost` with a `tabs` variable in `MainActivity.kt`:
+
+```kotlin
+val tabs = listOf(
+    HotwireBottomTab(
+        title = "Navigation",
+        iconResId = R.drawable.ic_tab_navigation,
+        configuration = NavigatorConfiguration(
+            name = "navigation",
+            navigatorHostId = R.id.navigation_navigator_host,
+            startLocation = "https://hotwire-native-demo.dev"
+        )
+    ),
+
+    HotwireBottomTab(
+        title = "Bridge Components",
+        iconResId = R.drawable.ic_tab_bridge_components,
+        configuration = NavigatorConfiguration(
+            name = "bridge-components",
+            navigatorHostId = R.id.bridge_components_navigator_host,
+            startLocation = "https://hotwire-native-demo.dev/components"
+        )
+    )
+)
+```
+
+This creates two tabs, Navigation and Bridge Components. The tab bar's menu is populated automatically from the tabs, so there's no need to create a menu resource.
+
+Each `HotwireBottomTab` requires the following parameters:
+
+* `title`: The string to display on the tab
+* `iconResId`: The [drawable resource](https://developer.android.com/develop/ui/views/graphics/drawables) to display as the tab's icon
+* `configuration`: The `NavigatorConfiguration` for the tab, with a unique `name`, the ID of the tab's `NavigatorHost` in your layout, and the URL to visit when the tab loads
+
+Optionally, pass `isVisible = false` to hide a tab.
+
+## Set up the controller
+
+Finally, replace the `MainActivity` class with the following to wire everything up with a `HotwireBottomNavigationController`:
+
+```kotlin
+class MainActivity : HotwireActivity() {
+    private lateinit var bottomNavigationController: HotwireBottomNavigationController
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        findViewById<View>(R.id.root).applyDefaultImeWindowInsets()
+
+        bottomNavigationController = HotwireBottomNavigationController(
+            activity = this,
+            view = findViewById(R.id.bottom_nav)
+        )
+        bottomNavigationController.load(tabs)
+    }
+
+    override fun navigatorConfigurations() = tabs.navigatorConfigurations
+}
+```
+
+Every tab's start location is loaded up front when `load()` is called, so switching tabs is instant. Pass a second argument to `load()` to select a different initial tab, and use `setOnTabSelectedListener` to be notified when the selected tab changes:
+
+```kotlin
+bottomNavigationController.load(tabs, selectedTabIndex = 1)
+bottomNavigationController.setOnTabSelectedListener { index, tab ->
+    // ...
+}
+```
+
+## Lazy loading
+
+Each tab performs a web visit for its start location. If loading every tab up front is too expensive, opt into lazy loading by passing `lazyLoadTabs = true` to the controller. A lazily loaded tab doesn't visit its start location until the user first selects it. The initially selected tab always loads right away.
+
+```kotlin
+HotwireBottomNavigationController(
+    activity = this,
+    view = findViewById(R.id.bottom_nav),
+    lazyLoadTabs = true
+)
+```

--- a/_source/android/02_tabs.md
+++ b/_source/android/02_tabs.md
@@ -115,7 +115,7 @@ class MainActivity : HotwireActivity() {
 }
 ```
 
-Every tab's start location is loaded up front when `load()` is called, so switching tabs is instant. Pass a second argument to `load()` to select a different initial tab, and use `setOnTabSelectedListener` to be notified when the selected tab changes:
+Every tab's start location is loaded up front, so switching tabs is instant. Pass a second argument to `load()` to select a different initial tab, and use `setOnTabSelectedListener` to be notified when the selected tab changes:
 
 ```kotlin
 bottomNavigationController.load(tabs, selectedTabIndex = 1)

--- a/_source/android/03_path_configuration.md
+++ b/_source/android/03_path_configuration.md
@@ -1,6 +1,6 @@
 ---
 permalink: /android/path-configuration.html
-order: 02
+order: 03
 title: "Path Configuration"
 description: "Customize Android app behavior via the path configuration."
 ---

--- a/_source/android/04_bridge_components.md
+++ b/_source/android/04_bridge_components.md
@@ -1,6 +1,6 @@
 ---
 permalink: /android/bridge-components.html
-order: 03
+order: 04
 title: "Bridge Components"
 description: "Bridge the gap with native bridge components driven by the web on Android."
 ---

--- a/_source/android/05_configuration.md
+++ b/_source/android/05_configuration.md
@@ -22,8 +22,7 @@ class MyApplication : Application() {
 }
 ```
 
-To ensure this invoked when the app starts, add the name of your `Application` instance to `AndroidManifest.xml` via the `android:name` property on the `<application>` node.
-p
+To ensure this is invoked when the app starts, add the name of your `Application` instance to `AndroidManifest.xml` via the `android:name` property on the `<application>` node.
 
 ```xml
 <application android:name=".MyApplication">
@@ -33,11 +32,31 @@ p
 
 ## Options
 
-Enable debugging in debug builds:
+Enable debug logging and WebView debugging in debug builds:
 
 ```kotlin
-Hotwire.config.debugLoggingEnabled = BuildConfig.DEBUG
+if (BuildConfig.DEBUG) {
+    Hotwire.config.logger.logLevel = HotwireLogLevel.DEBUG
+}
 Hotwire.config.webViewDebuggingEnabled = BuildConfig.DEBUG
+```
+
+By default, the library logs to Logcat with the log level set to `HotwireLogLevel.NONE`, so no logs are emitted. All library logging, including HTTP request logging, is controlled by the logger's `logLevel`. The available levels are `VERBOSE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, and `NONE`.
+
+To handle library logs in your app, for example to forward them to your own logging framework, provide a custom implementation of the [HotwireLogger](https://github.com/hotwired/hotwire-native-android/blob/main/core/src/main/kotlin/dev/hotwire/core/logging/HotwireLogger.kt) interface:
+
+```kotlin
+Hotwire.config.logger = MyAppLogger
+
+object MyAppLogger : HotwireLogger {
+    override var logLevel = HotwireLogLevel.DEBUG
+
+    override fun v(tag: String, msg: () -> String) { /* ... */ }
+    override fun d(tag: String, msg: () -> String) { /* ... */ }
+    override fun i(tag: String, msg: () -> String) { /* ... */ }
+    override fun w(tag: String, msg: () -> String) { /* ... */ }
+    override fun e(tag: String, throwable: Throwable?, msg: () -> String) { /* ... */ }
+}
 ```
 
 Set the default fragment destination:

--- a/_source/android/05_native_screens.md
+++ b/_source/android/05_native_screens.md
@@ -1,6 +1,6 @@
 ---
 permalink: /android/native-screens.html
-order: 04
+order: 05
 title: "Native Screens"
 description: "Integrate fully native Kotlin screens in your Hotiwre Native app."
 ---

--- a/_source/android/05_native_screens.md
+++ b/_source/android/05_native_screens.md
@@ -2,7 +2,7 @@
 permalink: /android/native-screens.html
 order: 05
 title: "Native Screens"
-description: "Integrate fully native Kotlin screens in your Hotiwre Native app."
+description: "Integrate fully native Kotlin screens in your Hotwire Native app."
 ---
 
 # Native Screens

--- a/_source/android/06_configuration.md
+++ b/_source/android/06_configuration.md
@@ -1,6 +1,6 @@
 ---
 permalink: /android/configuration.html
-order: 05
+order: 06
 title: "Configuration"
 description: "How to customize a Hotwire Native Android app."
 ---

--- a/_source/android/07_reference.md
+++ b/_source/android/07_reference.md
@@ -2,7 +2,7 @@
 permalink: /android/reference.html
 order: 07
 title: "Reference"
-description: "An reference guide to the Hotwire Native Android library."
+description: "A reference guide to the Hotwire Native Android library."
 ---
 
 # Reference

--- a/_source/android/07_reference.md
+++ b/_source/android/07_reference.md
@@ -1,6 +1,6 @@
 ---
 permalink: /android/reference.html
-order: 06
+order: 07
 title: "Reference"
 description: "An reference guide to the Hotwire Native Android library."
 ---

--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -159,7 +159,7 @@ By default, all external urls outside of your app's domain open externally. The 
 - `BrowserTabRouteDecisionHandler`: **(Android Only)** Routes all external `http`/`https` urls to a [Custom Tab](https://developer.chrome.com/docs/android/custom-tabs) in your app.
 - `SystemNavigationRouteDecisionHandler`: Routes all remaining external urls (such as `sms:` or `mailto:`) through device's system navigation.
 
-If you'd like to customize this behavior you can subclass the `RouteDecisionHandler` class in your app to provide your own implementation(s). Register your app's decision handlers in order of importance. To decide how a url should be routed, the registered `RouteDecisionHandler` instances are called in order. When a matching `RouteDecisionHandler` is found for a given url, its `handle()` function is called and no other `RouteDecisionHandler` instances will be subsequently called.
+If you'd like to customize this behavior you can implement the `RouteDecisionHandler` protocol (iOS) or interface (Android) in your app to provide your own implementation(s). Register your app's decision handlers in order of importance. To decide how a proposed visit should be routed, the registered `RouteDecisionHandler` instances are called in order. When a `RouteDecisionHandler` matching the proposal is found, its `handle()` function is called and no other `RouteDecisionHandler` instances will be subsequently called.
 
 **Example for iOS:**
 ```swift
@@ -175,6 +175,50 @@ Hotwire.registerRouteDecisionHandlers(
     AppNavigationRouteDecisionHandler(),
     MyCustomExternalRouteDecisionHandler()
 )
+```
+
+Each decision handler receives the full `VisitProposal`, so you can match on the proposed visit's location, visit options, or path configuration properties:
+
+**Example for iOS:**
+```swift
+class MyCustomExternalRouteDecisionHandler: RouteDecisionHandler {
+    let name = "my-custom-external"
+
+    func matches(proposal: VisitProposal,
+                 configuration: Navigator.Configuration) -> Bool {
+        proposal.url.host() == "external.example.com"
+    }
+
+    func handle(proposal: VisitProposal,
+                configuration: Navigator.Configuration,
+                navigator: Navigating) -> Router.Decision {
+        // Route the url however you like, then cancel the in-app navigation.
+        return .cancel
+    }
+}
+```
+
+**Example for Android:**
+```kotlin
+class MyCustomExternalRouteDecisionHandler : Router.RouteDecisionHandler {
+    override val name = "my-custom-external"
+
+    override fun matches(
+        proposal: VisitProposal,
+        configuration: NavigatorConfiguration
+    ): Boolean {
+        return proposal.location.toUri().host == "external.example.com"
+    }
+
+    override fun handle(
+        proposal: VisitProposal,
+        configuration: NavigatorConfiguration,
+        activity: HotwireActivity
+    ): Router.Decision {
+        // Route the url however you like, then cancel the in-app navigation.
+        return Router.Decision.CANCEL
+    }
+}
 ```
 
 ## Manual Navigation

--- a/_source/reference/navigation.md
+++ b/_source/reference/navigation.md
@@ -186,7 +186,7 @@ class MyCustomExternalRouteDecisionHandler: RouteDecisionHandler {
 
     func matches(proposal: VisitProposal,
                  configuration: Navigator.Configuration) -> Bool {
-        proposal.url.host() == "external.example.com"
+        proposal.url.host == "external.example.com"
     }
 
     func handle(proposal: VisitProposal,


### PR DESCRIPTION
Brings the Android docs in line with hotwire-native-android 1.3.0:

- **Logging**: `Hotwire.config.debugLoggingEnabled` was removed in 1.3.0 (hotwired/hotwire-native-android#159). Documents enabling debug logging via the default logger's `logLevel` and providing a custom `HotwireLogger`.
- **Route decision handlers**: handlers on both platforms now receive the full `VisitProposal` (hotwired/hotwire-native-ios#249, hotwired/hotwire-native-android#203). Updates the prose and adds implementation examples.
- **Tabs**: new page covering `HotwireBottomNavigationController` and `HotwireBottomTab`, including the lazy loading option. Android counterpart to #92; renumbers the later Android pages the same way.


Note: iOS documentation updates should be published at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)