### PR TITLE
Update logging configuration for debugging

### DIFF
--- a/_source/android/05_configuration.md
+++ b/_source/android/05_configuration.md
@@ -36,7 +36,7 @@ p
 Enable debugging in debug builds:
 
 ```kotlin
-Hotwire.config.debugLoggingEnabled = BuildConfig.DEBUG
+Hotwire.config.logger.logLevel = if (BuildConfig.DEBUG) HotwireLogLevel.DEBUG else HotwireLogLevel.NONE
 Hotwire.config.webViewDebuggingEnabled = BuildConfig.DEBUG
 ```
 


### PR DESCRIPTION
With the recent 1.3.0 [logging change](https://github.com/hotwired/hotwire-native-android/pull/159), I noticed that these instructions are out of date. 

